### PR TITLE
Rename "Required Properties to "Required or Implicit Properties" in "manifest-specification.htm

### DIFF
--- a/UPack/universal-packages/metacontent-guidance/manifest-specification.htm
+++ b/UPack/universal-packages/metacontent-guidance/manifest-specification.htm
@@ -14,7 +14,7 @@
         The <code>upack.json</code> file is a <a href="http://json.org/">JSON</a> object with the following properties.
     </p>
 
-    <h3 id="required-properties" data-title="Required Properties">Required Properties</h3>
+    <h3 id="required-properties" data-title="Required or Implicit Properties">Required or Implicit Properties</h3>
     <table>
         <thead>
             <tr>


### PR DESCRIPTION
Updated to more clearly reflect that group is an implicit property of the manifest.
Preserved the heading ID to avoid breaking existing hyperlinks.

Reasoning:

The `Required Properties` table lists `group`, `name`, and `version`. 

`name` and `version` are post-fixed with an "R" superscript to denote that they are required properties, but `group` is not, even though still listed in the "Required Properties" table.

A more informative title for the "Required Properties" table would be "Required or Implicit Properties". `group` appears to be "required" only in the since that it implicitly exists as an empty string even if not specified.